### PR TITLE
Refactor status messages

### DIFF
--- a/src/hooks/useStatusMessage.js
+++ b/src/hooks/useStatusMessage.js
@@ -1,0 +1,31 @@
+import { useStatus } from '../providers/MsgStatusProvider';
+
+export function useStatusMessage() {
+    const { setStatusType, setStatusMessage, setIsAlertOpen } = useStatus();
+
+    const success = message => {
+        setStatusType('success');
+        setStatusMessage(message);
+        setIsAlertOpen(true);
+    };
+
+    const error = message => {
+        setStatusType('error');
+        setStatusMessage(message);
+        setIsAlertOpen(true);
+    };
+
+    const info = message => {
+        setStatusType('info');
+        setStatusMessage(message);
+        setIsAlertOpen(true);
+    };
+
+    const hide = () => {
+        setIsAlertOpen(false);
+    };
+
+    return {
+        success, error, info, hide 
+    };
+}

--- a/src/pages/JobReferralPage.jsx
+++ b/src/pages/JobReferralPage.jsx
@@ -15,6 +15,7 @@ import PickCompany from '../compoents/PickCompany';
 import { useStatus } from '../providers/MsgStatusProvider';
 import JobForm from '../compoents/JobDetails';
 import JobReferralNotes from '../compoents/JobReferralNotes';
+import { useStatusMessage } from '../hooks/useStatusMessage';
 
 const steps = [
     'Company Details',
@@ -24,7 +25,8 @@ const steps = [
 
 export default function JobReferralPage() {
     const [ activeStep, setActiveStep ] = React.useState(0);
-    const { setStatusType, setStatusMessage, setIsAlertOpen } = useStatus();
+    const statusMessage = useStatusMessage();
+
     const [ answers, setAnswers ] = React.useState({
         department: null,
         department_size: null,
@@ -67,18 +69,14 @@ export default function JobReferralPage() {
                     if (!response.ok) {
                         // If not OK, throw an error to be caught in the catch block
                         return response.json().then(errorData => {
-                            setStatusMessage("We can't validate your request. Please try again");
-                            setIsAlertOpen(true);
-                            setStatusType('error');
+                            statusMessage.error("We can't validate your request. Please try again");
                             handleBack();
                         });
                     }
                     return response.json();
                 })
                 .then(data => {
-                    setStatusMessage('Your job post is in!');
-                    setIsAlertOpen(true);
-                    setStatusType('success');
+                    statusMessage.success('Your job post is in!');
                     history(`/job/${data.id}`);
                 })
                 .catch(error => {
@@ -166,13 +164,9 @@ export default function JobReferralPage() {
         }
         if (validationResult.isValid) {
             setActiveStep(activeStep + 1);
-            setStatusType('');
-            setStatusMessage('');
-            setIsAlertOpen(false);
+            statusMessage.hide();
         } else {
-            setStatusType('error');
-            setStatusMessage('Please update all required fields.');
-            setIsAlertOpen(true);
+            statusMessage.error('Please update all required fields.');
         }
     };
 

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,16 +1,17 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import {useAuth} from "../providers/AuthProvider";
-import {useNavigate} from "react-router";
-import Typography from "@mui/material/Typography";
-import Grid from "@mui/material/Grid";
-import {useStatus} from "../providers/MsgStatusProvider";
-import Link from "@mui/material/Link";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Checkbox from "@mui/material/Checkbox";
+import { useAuth } from '../providers/AuthProvider';
+import { useNavigate } from 'react-router';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import { useStatus } from '../providers/MsgStatusProvider';
+import Link from '@mui/material/Link';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
 import styled from '@emotion/styled';
-import Alert from "@mui/material/Alert";
+import Alert from '@mui/material/Alert';
+import { useStatusMessage } from '../hooks/useStatusMessage';
 
 const CenteredContent = styled.div`
     display: flex;
@@ -34,44 +35,42 @@ const ImageBG = styled.div`
 `;
 
 function LoginPage() {
-    const { login, user, isAuthenticated, errorMessage } = useAuth();
-    const {statusType, setStatusMessage, setIsAlertOpen, setStatusType} = useStatus();
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
-    const [rememberMe, setRememberMe] = useState(false);
+    const {
+        login, user, isAuthenticated, errorMessage 
+    } = useAuth();
+    const { statusType } = useStatus();
+    const statusMessage = useStatusMessage();
+
+    const [ username, setUsername ] = useState('');
+    const [ password, setPassword ] = useState('');
+    const [ rememberMe, setRememberMe ] = useState(false);
     const navigate = useNavigate();
 
-    const handleSubmit = async (event) => {
+    const handleSubmit = async event => {
         event.preventDefault();
         let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        let emailLower = username.toLocaleLowerCase()
+        let emailLower = username.toLocaleLowerCase();
         await login(emailLower, emailLower, password, timezone);
     };
 
     useEffect(() => {
         if (user?.length > 0) {
-            navigate('/', {replace: true});
+            navigate('/', { replace: true });
         }
-    }, [user]);
+    }, [ user ]);
 
     useEffect(() => {
-        if (errorMessage) {
-            if (errorMessage['non_field_errors']) {
-                setStatusMessage(errorMessage['non_field_errors'][0])
-                setStatusType('error');
-                setIsAlertOpen(true)
-            }
-
-        } else {
-            setStatusMessage('');
-            setIsAlertOpen(false);
+        if (!errorMessage) {
+            statusMessage.hide();
+            return;
         }
-    }, [errorMessage]);
 
+        if (errorMessage['non_field_errors']) {
+            statusMessage.error(errorMessage['non_field_errors'][0]);
+        }
+    }, [ errorMessage ]);
 
-    function handleRememberMeChange() {
-
-    }
+    function handleRememberMeChange() {}
 
     return (
         <Grid container id="top">
@@ -83,16 +82,17 @@ function LoginPage() {
                             <Typography variant="h3" align="center">
                                 You are already logged in
                             </Typography>
-                        ) : (<>
+                        ) : (
+                            <>
                                 <Typography variant="h3" component="h1" align="center">
                                     Login
                                 </Typography>
                                 {errorMessage?.length > 0 &&
-                                errorMessage.map((error, index) => (
-                                    <Alert key={index} severity={statusType}>
-                                        {error} test
-                                    </Alert>
-                                ))}
+                                    errorMessage.map((error, index) => (
+                                        <Alert key={index} severity={statusType}>
+                                            {error} test
+                                        </Alert>
+                                    ))}
 
                                 <form onSubmit={handleSubmit}>
                                     <TextField
@@ -102,7 +102,7 @@ function LoginPage() {
                                         label="Email"
                                         type="text"
                                         value={username}
-                                        onChange={(event) => setUsername(event.target.value)}
+                                        onChange={event => setUsername(event.target.value)}
                                         margin="normal"
                                         fullWidth
                                     />
@@ -114,27 +114,15 @@ function LoginPage() {
                                         label="Password"
                                         type="password"
                                         value={password}
-                                        onChange={(event) => setPassword(event.target.value)}
+                                        onChange={event => setPassword(event.target.value)}
                                         margin="normal"
                                         fullWidth
                                     />
                                     <FormControlLabel
-                                        control={
-                                            <Checkbox
-                                                checked={rememberMe}
-                                                onChange={handleRememberMeChange}
-                                                name="rememberMe"
-                                                color="primary"
-                                            />
-                                        }
+                                        control={<Checkbox checked={rememberMe} onChange={handleRememberMeChange} name="rememberMe" color="primary" />}
                                         label="Remember me"
                                     />
-                                    <Button
-                                        variant="contained"
-                                        color="primary"
-                                        fullWidth={true}
-                                        type="submit"
-                                    >
+                                    <Button variant="contained" color="primary" fullWidth={true} type="submit">
                                         Log in
                                     </Button>
                                     <Link href="/forgot-password" variant="body2">
@@ -149,10 +137,16 @@ function LoginPage() {
                     </FormContainer>
                 </CenteredContent>
 
-            {/*    */}
+                {/*    */}
             </Grid>
             <Grid item xs={12} sm={6}>
-                <ImageBG id="right" style={{backgroundImage: 'https://uploads-ssl.webflow.com/5fc4802f4edc553647330622/5fd04d6d1ea5ad04a37db102_pexels-jopwell-2422290-p-1600.jpeg'}}/>
+                <ImageBG
+                    id="right"
+                    style={{
+                        backgroundImage:
+                            'https://uploads-ssl.webflow.com/5fc4802f4edc553647330622/5fd04d6d1ea5ad04a37db102_pexels-jopwell-2422290-p-1600.jpeg',
+                    }}
+                />
             </Grid>
         </Grid>
     );

--- a/src/pages/MemberSignupPage.jsx
+++ b/src/pages/MemberSignupPage.jsx
@@ -9,6 +9,7 @@ import { useStatus } from '../providers/MsgStatusProvider';
 import Link from '@mui/material/Link';
 import styled from '@emotion/styled';
 import Alert from '@mui/material/Alert';
+import { useStatusMessage } from '../hooks/useStatusMessage';
 
 const CenteredContent = styled.div`
     display: flex;
@@ -33,9 +34,9 @@ const ImageBG = styled.div`
 
 function LoginPage() {
     const auth = useAuth();
-    const {
-        statusType, setStatusMessage, setIsAlertOpen, setStatusType 
-    } = useStatus();
+    const { statusType } = useStatus();
+    const statusMessage = useStatusMessage();
+
     const [ formData, setFormData ] = useState({
         first_name: '',
         last_name: '',
@@ -63,22 +64,16 @@ function LoginPage() {
                 if (data.status) {
                     setToken(data.token);
                     localStorage.setItem('token', data.token);
-                    setIsAlertOpen(true);
-                    setStatusType('success');
-                    setStatusMessage('Welcome to Tech by Choice');
+                    statusMessage.success('Welcome to Tech by Choice');
                     navigate('/new/member/2');
                 } else {
                     console.error('Error:', data.message);
-                    setIsAlertOpen(true);
-                    setStatusType('error');
-                    setStatusMessage(data.message);
+                    statusMessage.error(data.message);
                 }
             })
             .catch(error => {
                 console.error('Error:', error);
-                setIsAlertOpen(true);
-                setStatusType('error');
-                setStatusMessage(error.message);
+                statusMessage.error(error.message);
             });
     };
 
@@ -94,15 +89,13 @@ function LoginPage() {
     }, [ auth.user ]);
 
     useEffect(() => {
-        if (auth.errorMessage) {
-            if (auth.errorMessage['non_field_errors']) {
-                setStatusMessage(auth.errorMessage['non_field_errors'][0]);
-                setStatusType('error');
-                setIsAlertOpen(true);
-            }
-        } else {
-            setStatusMessage('');
-            setIsAlertOpen(false);
+        if (!auth.errorMessage) {
+            statusMessage.hide();
+            return;
+        }
+
+        if (auth.errorMessage['non_field_errors']) {
+            statusMessage.error(auth.errorMessage['non_field_errors'][0]);
         }
     }, [ auth.errorMessage ]);
 

--- a/src/pages/NewMemeberPage.jsx
+++ b/src/pages/NewMemeberPage.jsx
@@ -19,6 +19,7 @@ import CommunityQuestionsStep from '../compoents/onboarding/CommunityQuestionsSt
 import MarketingQuestionsStep from '../compoents/onboarding/MarketingQuestionsSteps';
 import getCookie from '../helpers';
 import { useAuth } from '../providers/AuthProvider';
+import { useStatusMessage } from '../hooks/useStatusMessage';
 
 const steps = [
     'Basic Info',
@@ -31,12 +32,13 @@ const steps = [
 export default function NewMemberPage() {
     const [ activeStep, setActiveStep ] = React.useState(0);
     const [ questions, setQuestions ] = React.useState(0);
-    const { setStatusType, setStatusMessage, setIsAlertOpen } = useStatus();
     const [ answers, setAnswers ] = React.useState({});
     const [ formErrors, setFormErrors ] = React.useState({});
 
+    const statusMessage = useStatusMessage();
     const history = useNavigate();
     const { token, logout } = useAuth();
+
     useEffect(() => {}, [ answers ]);
 
     useEffect(() => {
@@ -218,13 +220,9 @@ export default function NewMemberPage() {
         }
         if (validationResult.isValid) {
             setActiveStep(activeStep + 1);
-            setStatusType('');
-            setStatusMessage();
-            setIsAlertOpen(false);
+            statusMessage.hide();
         } else {
-            setStatusType('error');
-            setStatusMessage('Please update all required fields.');
-            setIsAlertOpen(true);
+            statusMessage.error('Please update all required fields.');
         }
     };
 
@@ -256,16 +254,12 @@ export default function NewMemberPage() {
             })
             .then(data => {
                 // Handle the successful JSON response here, e.g.:
-                setStatusMessage("You're in!");
-                setIsAlertOpen(true);
-                setStatusType('success');
+                statusMessage.success("You're in!");
                 history('/');
             })
             .catch(error => {
                 console.error('Fetch error:', error);
-                setStatusMessage('We ran into an error saving your profile');
-                setIsAlertOpen(true);
-                setStatusType('error');
+                statusMessage.error('We ran into an error saving your profile');
             });
     };
 

--- a/src/pages/NewMentorPage.jsx
+++ b/src/pages/NewMentorPage.jsx
@@ -14,6 +14,7 @@ import FormMentorCareer from '../compoents/mentorship/FormMentorCareer';
 import FormMentorProfile from '../compoents/mentorship/FormMentorProfile';
 import FormMentorshipValues from '../compoents/mentorship/FormMentorshipValues';
 import { useStatus } from '../providers/MsgStatusProvider';
+import { useStatusMessage } from '../hooks/useStatusMessage';
 
 const steps = [
     'Commitment Level',
@@ -77,7 +78,7 @@ const NextBackButtons = ({ activeStep, handleBack, handleNext }) => (
 export default function NewMentorPage() {
     const [ hasCompleted, setHasCompleted ] = React.useState(false);
     const [ activeStep, setActiveStep ] = React.useState(0);
-    const { setStatusType, setStatusMessage, setIsAlertOpen } = useStatus();
+    const statusMessage = useStatusMessage();
 
     const [ formData, setFormData ] = React.useState({
         commitmentLevel: null,
@@ -171,10 +172,7 @@ export default function NewMentorPage() {
                 setActiveStep(activeStep + 1);
             }
         } catch (error) {
-            setStatusType('error');
-            setStatusMessage(error.message);
-            setIsAlertOpen(true);
-
+            statusMessage.error(error.message);
             console.error('Save failed');
         }
     };

--- a/src/pages/ViewJobPage.jsx
+++ b/src/pages/ViewJobPage.jsx
@@ -6,6 +6,7 @@ import Container from '@mui/material/Container';
 import CompanyCard from '../compoents/CompanyCard';
 import { Link } from 'react-router-dom';
 import { useStatus } from '../providers/MsgStatusProvider';
+import { useStatusMessage } from '../hooks/useStatusMessage';
 
 const HtmlContentRenderer = ({ htmlContent }) => {
     return <div dangerouslySetInnerHTML={{ __html: htmlContent }} />;
@@ -21,6 +22,8 @@ function ViewJobPage({ userDetail, isLoading }) {
     const [ jobData, setJobData ] = useState();
     const [ jobStatusCard, setJobStatusCard ] = useState(null);
     const { setStatusMessage, setIsAlertOpen, setStatusType } = useStatus();
+    const statusMessage = useStatusMessage();
+
     const isOwnProfile = userDetail?.user_info.id === jobData?.created_by_id;
     const isStaffOrEditor = userDetail?.account_info?.is_staff || jobData?.created_by_id === userDetail?.user_info?.id;
 
@@ -65,17 +68,13 @@ function ViewJobPage({ userDetail, isLoading }) {
                 if (!response.ok) {
                     // If not OK, throw an error to be caught in the catch block
                     return response.json().then(errorData => {
-                        setStatusMessage("Sorry it looks like we can't publish your job");
-                        setIsAlertOpen(true);
-                        setStatusType('error');
+                        statusMessage.error("Sorry it looks like we can't publish your job");
                     });
                 }
                 return response.json();
             })
             .then(data => {
-                setStatusMessage("We're reviewing your job now");
-                setIsAlertOpen(true);
-                setStatusType('success');
+                statusMessage.success("We're reviewing your job now");
             })
             .catch(error => {
                 console.error('There was an error publish the job', error);
@@ -99,17 +98,13 @@ function ViewJobPage({ userDetail, isLoading }) {
                 if (!response.ok) {
                     // If not OK, throw an error to be caught in the catch block
                     return response.json().then(errorData => {
-                        setStatusMessage("Sorry it looks like we can't pause your job");
-                        setIsAlertOpen(true);
-                        setStatusType('error');
+                        statusMessage.error("Sorry it looks like we can't pause your job");
                     });
                 }
                 return response.json();
             })
             .then(data => {
-                setStatusMessage("We've paused your job");
-                setIsAlertOpen(true);
-                setStatusType('success');
+                statusMessage.success("We've paused your job");
             })
             .catch(error => {
                 console.error('There was an error publish the job', error);
@@ -134,17 +129,13 @@ function ViewJobPage({ userDetail, isLoading }) {
                     // If not OK, throw an error to be caught in the catch block
                     return response.json().then(errorData => {
                         console.log(errorData);
-                        setStatusMessage("Sorry it looks like we can't close your job");
-                        setIsAlertOpen(true);
-                        setStatusType('error');
+                        statusMessage.error("Sorry it looks like we can't close your job");
                     });
                 }
                 return response.json();
             })
             .then(data => {
-                setStatusMessage("We've closed your job now");
-                setIsAlertOpen(true);
-                setStatusType('success');
+                statusMessage.success("We've closed your job now");
             })
             .catch(error => {
                 console.error('There was an error publish the job', error);
@@ -167,17 +158,13 @@ function ViewJobPage({ userDetail, isLoading }) {
                         // If not OK, throw an error to be caught in the catch block
                         return response.json().then(errorData => {
                             console.log(errorData);
-                            setStatusMessage("Sorry it looks like we can't publish your job");
-                            setIsAlertOpen(true);
-                            setStatusType('error');
+                            statusMessage.error("Sorry it looks like we can't publish your job");
                         });
                     }
                     return response.json();
                 })
                 .then(data => {
-                    setStatusMessage('Job is now active');
-                    setIsAlertOpen(true);
-                    setStatusType('success');
+                    statusMessage.success('Job is now active');
                 })
                 .catch(error => {
                     console.error('There was an error publish the job', error);


### PR DESCRIPTION
This PR adds a `useStatusMessage()` hook, which provides helper functions for displaying or hiding success/error status messages; this eliminates the need for multiple state-setting calls just to display a single message.

It also refactors all `./pages/*.jsx` files to use this hook.

For example, this code:
```js
setStatusType('error');
setStatusMessage('Some error message');
setIsAlertOpen(true);
```

can be replaced with:
```js
statusMessage.error('Some error message');
```
Which assumes, of course, that the hook has been imported in the current scope using `useStatusMessage()`.

- To display a success status message, use `statusMessage.success()`.
- To hide the status message banner, use `statusMessage.hide()`.

ping @DeltaV93 